### PR TITLE
Update mod_R.c

### DIFF
--- a/mod_R.c
+++ b/mod_R.c
@@ -561,7 +561,7 @@ static const char *AP_cmd_RSourceOnStartup(cmd_parms *cmd, void *conf, const cha
    }
    apr_table_add(
          MR_OnStartup,
-         apr_psprintf( cmd->pool, "%s on line %u of %s",
+         apr_psprintf( cmd->pool, "e:%s on line %u of %s",
             d->directive,d->line_num,d->filename),
          apr_psprintf(cmd->pool,"source('%s')",file)
          );


### PR DESCRIPTION
R source pointed by RSourceOnStartup was not parsed due to the missing key "e:"
