### PR TITLE
changed depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libapache2-mod-r-base
 Section: web
 Priority: optional
 Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
-Build-Depends: debhelper (>= 4.2.20), lsb-release, apache2-prefork-dev (>= 2.0.52-1), apache2-mpm-prefork, libapreq2-dev, r-base-core, r-base-dev
+Build-Depends: debhelper (>= 4.2.20), lsb-release, apache2-prefork-dev (>= 2.0.52-1) | apache2-dev (>= 2.4), apache2-mpm-prefork, libapreq2-dev, r-base-core, r-base-dev
 Standards-Version: 3.7.2
 
 Package: libapache2-mod-r-base


### PR DESCRIPTION
Starting Apache 2.4, the `apache2-prefork-dev` has been renamed to `apache2-dev` in Debian and Ubuntu. 
