### PR TITLE
reverse depends order

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libapache2-mod-r-base
 Section: web
 Priority: optional
 Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
-Build-Depends: debhelper (>= 4.2.20), lsb-release, apache2-prefork-dev (>= 2.0.52-1) | apache2-dev (>= 2.4), apache2-mpm-prefork, libapreq2-dev, r-base-core, r-base-dev
+Build-Depends: debhelper (>= 4.2.20), lsb-release, apache2-dev (>= 2.4) | apache2-prefork-dev (>= 2.0.52-1), apache2-mpm-prefork, libapreq2-dev, r-base-core, r-base-dev
 Standards-Version: 3.7.2
 
 Package: libapache2-mod-r-base


### PR DESCRIPTION
The order of the build-depends needs to be reversed, such that the more recent `apache2-dev` is specified first and has has preference.

I'm sorry for not getting this right the first time :)
