### PR TITLE
Updating dependencies for Apache2 in Ubuntu 13.10 and Debian 8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-libapache2-mod-r-base (1.1.15-ppa2) lucid; urgency=low
+libapache2-mod-r-base (1.2.4-raring5) raring; urgency=low
 
-  * Binary package release for rApache 1.1.15
+  * Updates for compatibility with Apache 2.4
 
- -- Jeffrey Horner <jeffrey.horner@gmail.com>  Thu, 05 Jan 2012 11:08:00 -0600
+ -- Jeroen Ooms <jeroen@opencpu.org>  Tue, 15 Oct 2013 11:08:00 -0600
+
 libapache2-mod-r-base (1.1.14-ppa3) lucid; urgency=low
 
   * Binary package release for rApache 1.1.14

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: libapache2-mod-r-base
 Section: web
 Priority: optional
 Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
-Build-Depends: debhelper (>= 4.2.20), lsb-release, apache2-prefork-dev (>= 2.0.52-1) | apache2-dev (>= 2.4), apache2-mpm-prefork, libapreq2-dev, r-base-core, r-base-dev
+Build-Depends: debhelper (>= 4.2.20), lsb-release, apache2-prefork-dev, apache2-mpm-prefork, libapreq2-dev, r-base-core, r-base-dev
 Standards-Version: 3.7.2
 
 Package: libapache2-mod-r-base
 Architecture: any
-Depends: apache2-mpm-prefork | apache2-mpm-worker, apache2.2-common, libapreq2, r-base-core, ${shlibs:Depends}
+Depends: apache2-mpm-prefork | apache2-mpm-worker, apache2-bin | apache2.2-common, libapreq2-3 | libapreq2, r-base-core, ${shlibs:Depends}
 Description: Apache module for running server-side R programs
  This package provides the R module for the Apache 2 webserver. Note
  that it will work with either Apache's prefork or worker MPM. Prefork


### PR DESCRIPTION
Sorry for another fix, want to make sure things work when Saucy is released. I'm quite sure I got it right now, successfully build and installed on Ubuntu 12.04, 12.10, 13.04 and 13.10. 
